### PR TITLE
fix: @nuxtjs/toast is working fine with bridge

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -198,7 +198,7 @@
     },
     {
         "name": "@nuxtjs/toast",
-        "bridge": "unknown",
+        "bridge": "ready",
         "core": "bugged",
         "maintainers": "-",
         "repoUrl": "https://github.com/nuxt-community/community-modules"


### PR DESCRIPTION
I've used the tutorial for [Nuxt bridge](https://v3.nuxtjs.org/getting-started/bridge) and the [setup here](https://github.com/nuxt-community/community-modules/tree/master/packages/toast#setup) and it's working great!