### PR TITLE
fix: @nuxtjs/google-fonts is working fine with bridge

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -169,7 +169,7 @@
     },
     {
         "name": "@nuxtjs/google-fonts",
-        "bridge": "unknown",
+        "bridge": "ready",
         "core": "bugged",
         "maintainers": "@ricardogobbosouza",
         "repoUrl": "https://github.com/nuxt-community/google-fonts-module"


### PR DESCRIPTION
I've used the tutorial for [Nuxt bridge](https://v3.nuxtjs.org/getting-started/bridge) and the [setup here](https://github.com/nuxt-community/google-fonts-module#setup) and it's working great!

I've added this kind of setup in my `nuxt.config.js`
```js
buildModules: [
  [
    '@nuxtjs/google-fonts',
    {
      families: {
        'Birthstone Bounce': {
          wght: [400, 500],
        },
      },
      subsets: 'latin',
      display: 'swap',
      prefetch: false,
      preconnect: false,
      preload: false,
      download: true,
      // base64: true,
    },
  ],
],
```

Then tried it in a `.vue` component
```html
<template>
  <div>working fine</div>
</template>

<script>
export default {}
</script>

<style>
div {
  font-family: 'Birthstone Bounce';
  font-size: 12rem;
}
</style>
```

![image](https://user-images.githubusercontent.com/5133074/138638463-b6d4b623-127f-46ea-8ddb-4e76e7a2e973.png)
