### PR TITLE
chore: add status for @nuxtjs/storybook

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -209,5 +209,13 @@
         "core": "unknown",
         "maintainers": "@pi0",
         "repoUrl": "https://github.com/nuxt-community/proxy-module"
+    },
+    {
+        "name": "@nuxtjs/storybook",
+        "bridge": "unknown",
+        "core": "bugged",
+        "maintainers": "@pi0",
+        "repoUrl": "https://github.com/nuxt-community/storybook",
+        "issueUrl": "https://github.com/nuxt-community/storybook/issues/330"
     }
 ]


### PR DESCRIPTION
Didn't tried it with Bridge, but it looks like that it doesn't work with Nuxt3: https://github.com/nuxt-community/storybook/issues/330