### PR TITLE
chore: add status for storyblok-nuxt

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -209,5 +209,13 @@
         "core": "unknown",
         "maintainers": "@pi0",
         "repoUrl": "https://github.com/nuxt-community/proxy-module"
+    },
+    {
+        "name": "storyblok-nuxt",
+        "bridge": "unknown",
+        "core": "bugged",
+        "maintainers": "@DominikAngerer",
+        "repoUrl": "https://github.com/storyblok/storyblok-nuxt",
+        "issueUrl": "https://github.com/storyblok/storyblok-nuxt/issues/62"
     }
 ]


### PR DESCRIPTION
Didn't tried it with Bridge, but it looks like that it doesn't work with Nuxt3: https://github.com/storyblok/storyblok-nuxt/issues/62